### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,15 +12,15 @@ TwigMotor	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-step	       KEYWORD2
-setSpeed       KEYWORD2
-changeAddress  KEYWORD2
+step	KEYWORD2
+setSpeed	KEYWORD2
+changeAddress	KEYWORD2
 
 ######################################
 # Instances (KEYWORD2)
 #######################################
 direction	KEYWORD2
-speed	        KEYWORD2
+speed	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords